### PR TITLE
Remove line breaks in the message to print

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ async function run() {
     }
 
     // Suffix comment with hidden value to check for updating later.
-    const commentIdSuffix = `\n\n\n<hidden purpose="for-rewritable-pr-comment-action-use" value="${comment_id}"></hidden>`;
+    const commentIdSuffix = `<hidden purpose="for-rewritable-pr-comment-action-use" value="${comment_id}"></hidden>`;
 
     // If comment already exists, get the comment ID.
     const existingCommentId = await checkForExistingComment(


### PR DESCRIPTION
# Description

Hey! 👋🏻 

When using this action, it prints the `<hidden>` tag with 3 `\n` before which makes the comment message looks weird.

<img width="929" alt="image" src="https://user-images.githubusercontent.com/30227758/212184835-43ce68dc-c1e0-499f-bcf5-6ce827c77962.png">

Deleting these line breaks shouldn't break anything in terms of Markdown.

<img width="927" alt="image" src="https://user-images.githubusercontent.com/30227758/212185292-3f36159c-aab1-432c-a5c1-7aebd3fcaaa3.png">

<img width="917" alt="image" src="https://user-images.githubusercontent.com/30227758/212184937-ba392426-0a7a-47c1-a161-a5d46e29fbdf.png">